### PR TITLE
Fix: don't display prompt for non-code cells

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,4 +4,4 @@ channels:
 dependencies:
 - jupyterlab=3
 - pip:
-  - jupyterlab-notifications==0.1.3
+  - jupyterlab-notifications==0.1.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-notifications",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Jupyterlab extension to show notebook cell completion browser notifications",
   "keywords": [
     "jupyter",

--- a/tutorial/demo.ipynb
+++ b/tutorial/demo.ipynb
@@ -2,14 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-03-19T03:37:14.667688Z",
-     "iopub.status.busy": "2021-03-19T03:37:14.667455Z",
-     "iopub.status.idle": "2021-03-19T03:37:14.671324Z",
-     "shell.execute_reply": "2021-03-19T03:37:14.670402Z",
-     "shell.execute_reply.started": "2021-03-19T03:37:14.667662Z"
+     "iopub.execute_input": "2021-03-27T03:06:18.533459Z",
+     "iopub.status.busy": "2021-03-27T03:06:18.533220Z",
+     "iopub.status.idle": "2021-03-27T03:06:18.537331Z",
+     "shell.execute_reply": "2021-03-27T03:06:18.536387Z",
+     "shell.execute_reply.started": "2021-03-27T03:06:18.533425Z"
     },
     "tags": []
    },
@@ -28,14 +28,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-03-19T03:37:16.906751Z",
-     "iopub.status.busy": "2021-03-19T03:37:16.906516Z",
-     "iopub.status.idle": "2021-03-19T03:37:20.035526Z",
-     "shell.execute_reply": "2021-03-19T03:37:20.034900Z",
-     "shell.execute_reply.started": "2021-03-19T03:37:16.906728Z"
+     "iopub.execute_input": "2021-03-27T03:06:19.213426Z",
+     "iopub.status.busy": "2021-03-27T03:06:19.213237Z",
+     "iopub.status.idle": "2021-03-27T03:06:22.337638Z",
+     "shell.execute_reply": "2021-03-27T03:06:22.336868Z",
+     "shell.execute_reply.started": "2021-03-27T03:06:19.213404Z"
     },
     "tags": []
    },
@@ -52,6 +52,49 @@
     "!sleep 3\n",
     "print(\"hello world!\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hello World"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-03-27T02:29:48.597351Z",
+     "iopub.status.busy": "2021-03-27T02:29:48.597122Z",
+     "iopub.status.idle": "2021-03-27T02:29:48.602494Z",
+     "shell.execute_reply": "2021-03-27T02:29:48.600860Z",
+     "shell.execute_reply.started": "2021-03-27T02:29:48.597324Z"
+    }
+   },
+   "source": [
+    "<h1>Hello World</h1>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -77,7 +120,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix #3 

**Problem**
Prompt for enabling `{recordTiming: True}` was showing up for markdown and raw cells that didn't have any code execution metadata. 

**Solution**
This adds a fix to only show this prompt for non empty code cells that don't have the execution metadata. 
