### PR TITLE
Fix: Use execution input for cell execution start time

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@ import { checkBrowserNotificationSettings } from './settings';
 function extractExecutionMetadata(metadata: IObservableJSON): [Date, Date] {
   const executionMetadata = Object.assign({}, metadata.get('execution') as any);
   const cellStartTime = new Date(
-    executionMetadata['shell.execute_reply.started'] || executionMetadata['iopub.execute_input']
+    executionMetadata['shell.execute_reply.started'] ||
+      executionMetadata['iopub.execute_input']
   );
   const cellEndTime = new Date(executionMetadata['shell.execute_reply']);
   return [cellStartTime, cellEndTime];

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { checkBrowserNotificationSettings } from './settings';
 function extractExecutionMetadata(metadata: IObservableJSON): [Date, Date] {
   const executionMetadata = Object.assign({}, metadata.get('execution') as any);
   const cellStartTime = new Date(
-    executionMetadata['shell.execute_reply.started']
+    executionMetadata['shell.execute_reply.started'] || executionMetadata['iopub.execute_input']
   );
   const cellEndTime = new Date(executionMetadata['shell.execute_reply']);
   return [cellStartTime, cellEndTime];

--- a/tutorial/julia_demo.ipynb
+++ b/tutorial/julia_demo.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e80893c2-fa00-440a-baf9-ac49aad29be5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-19T20:53:28.895000-06:00",
+     "iopub.status.busy": "2021-04-19T20:53:28.895000-06:00",
+     "iopub.status.idle": "2021-04-19T20:53:32.912000-06:00",
+     "shell.execute_reply": "2021-04-19T20:53:32.911000-06:00"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello world!"
+     ]
+    }
+   ],
+   "source": [
+    "sleep(4)\n",
+    "print(\"hello world!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90628a40-aae7-4b1d-a17a-5f03bea0aebf",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.6.0",
+   "language": "julia",
+   "name": "julia-1.6"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorial/py3_demo.ipynb
+++ b/tutorial/py3_demo.ipynb
@@ -2,14 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-03-27T03:06:18.533459Z",
-     "iopub.status.busy": "2021-03-27T03:06:18.533220Z",
-     "iopub.status.idle": "2021-03-27T03:06:18.537331Z",
-     "shell.execute_reply": "2021-03-27T03:06:18.536387Z",
-     "shell.execute_reply.started": "2021-03-27T03:06:18.533425Z"
+     "iopub.execute_input": "2021-04-20T02:52:00.612541Z",
+     "iopub.status.busy": "2021-04-20T02:52:00.612207Z",
+     "iopub.status.idle": "2021-04-20T02:52:00.616928Z",
+     "shell.execute_reply": "2021-04-20T02:52:00.615808Z",
+     "shell.execute_reply.started": "2021-04-20T02:52:00.612490Z"
     },
     "tags": []
    },
@@ -28,14 +28,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-03-27T03:06:19.213426Z",
-     "iopub.status.busy": "2021-03-27T03:06:19.213237Z",
-     "iopub.status.idle": "2021-03-27T03:06:22.337638Z",
-     "shell.execute_reply": "2021-03-27T03:06:22.336868Z",
-     "shell.execute_reply.started": "2021-03-27T03:06:19.213404Z"
+     "iopub.execute_input": "2021-04-20T02:52:00.619017Z",
+     "iopub.status.busy": "2021-04-20T02:52:00.618717Z",
+     "iopub.status.idle": "2021-04-20T02:52:03.748053Z",
+     "shell.execute_reply": "2021-04-20T02:52:03.746867Z",
+     "shell.execute_reply.started": "2021-04-20T02:52:00.618964Z"
     },
     "tags": []
    },
@@ -51,6 +51,24 @@
    "source": [
     "!sleep 3\n",
     "print(\"hello world!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-20T02:52:03.751413Z",
+     "iopub.status.busy": "2021-04-20T02:52:03.751066Z",
+     "iopub.status.idle": "2021-04-20T02:52:07.882434Z",
+     "shell.execute_reply": "2021-04-20T02:52:07.881588Z",
+     "shell.execute_reply.started": "2021-04-20T02:52:03.751375Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!sleep 4"
    ]
   },
   {


### PR DESCRIPTION
**Problem**
Julia Kernel does not have the `shell.execute_reply.started` attribute in the cell execution metadata, so the extension wasn't able to calculate the cell execution time and failed to display the notification. 

**Solution**
This fix is to use `iopub.execute_input` when `shell.execute_reply.started` is non-existent. `iopub.execute_input` is emitted when a cell execute request is made. 

Fixes #6 