### PR TITLE
Add notebook's name in the notification message.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ function extractExecutionMetadata(metadata: IObservableJSON): [Date, Date] {
 function displayNotification(
   cellDuration: string,
   cellNumber: number,
+  notebookName: string,
   reportCellNumber: boolean,
   reportCellExecutionTime: boolean
 ): void {
@@ -42,8 +43,9 @@ function displayNotification(
   } else if (reportCellExecutionTime) {
     message = `Cell Duration: ${cellDuration}`;
   }
+
   notificationPayload.body = message;
-  new Notification('Notebook Cell Completed!', notificationPayload);
+  new Notification(`${notebookName} Cell Completed!`, notificationPayload);
 }
 
 const extension: JupyterFrontEndPlugin<void> = {
@@ -86,9 +88,11 @@ const extension: JupyterFrontEndPlugin<void> = {
             if (diff.getSeconds() >= minimumCellExecutionTime) {
               const cellDuration = diff.toISOString().substr(11, 8);
               const cellNumber = notebook.activeCellIndex;
+              const notebookName = notebook.title.label;
               displayNotification(
                 cellDuration,
                 cellNumber,
+                notebookName,
                 reportCellNumber,
                 reportCellExecutionTime
               );


### PR DESCRIPTION
This PR adds a notebook's name in the notification message.
I appreciate you if you review this PR.

## Motivation
Since the Jupyterlab allows opening multiple files in different tabs, sometimes I run multiple cells simultaneously. I think showing which execution has finished in the notification message is very helpful.

## About Modification
The notebook's name is obtained from `notebook.title.label`.
I could not found any official documentation that the `notebook.title.label` has the notebook name. But current implementation gives the name, and I think it is a natural assumption.

## Output example

This is an example with `py3_deom.ipynb` file.

<img width="338" alt="notification_image" src="https://user-images.githubusercontent.com/9190086/117570859-0f07f800-b107-11eb-93bf-9a8941409192.png">

