### PR TITLE
The `minimum_cell_execution_time` does not work properly if it is >60

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ const extension: JupyterFrontEndPlugin<void> = {
               metadata
             );
             const diff = new Date(<any>cellEndTime - <any>cellStartTime);
-            if (diff.getSeconds() >= minimumCellExecutionTime) {
+            if (diff.getTime() / 1000 >= minimumCellExecutionTime) {
               const cellDuration = diff.toISOString().substr(11, 8);
               const cellNumber =
                 cellNumberType === 'cell_index'


### PR DESCRIPTION
Notification does not seem to be triggered properly if the `minimum_cell_execution_time` is set larger than 60 seconds.

The current implementation uses the method `diff.getSeconds()`, but it seems to return the seconds part of the timestamp instead of the timestamp in seconds.

To fix this, I replaced it by `diff.getTime() / 1000`.

I appreciate it if you could confirm this.