### PR TITLE
Silent when permission granted

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,9 +8,7 @@ function checkNotificationPromise(): boolean {
 }
 
 function handlePermission(permission: string): void {
-  if (permission === 'granted') {
-    alert('Browser Notifications are allowed. (^_^)b');
-  } else {
+  if (permission !== 'granted') {
     alert(
       'Browser Notifications are not allowed. Please update your browser settings to allow notifications.'
     );


### PR DESCRIPTION
Only prompt users when something is wrong can make it less noisy. Especially when deploy JupyterLab on clusters.