### PR TITLE
Option to only get notified for the last selected cell execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Use the following settings to update cell execution time for a notification and 
 
     // Trigger only for the last selected notebook cell execution.
     // Trigger a notification only for the last selected executed notebook cell.
+    // NOTE: Only Available in version >= v0.3.0
     "last_cell_only": false,
 
     // Minimum Notebook Cell Execution Time
@@ -66,7 +67,8 @@ Use the following settings to update cell execution time for a notification and 
     "minimum_cell_execution_time": 60,
 
     // Report Notebook Cell Execution Time
-    // Display notebook cell execution time in the notification.
+    // Display notebook cell execution time in the notification. 
+    // If last_cell_only is set to true, the total duration of the selected cells will be displayed.
     "report_cell_execution_time": true,
 
     // Report Notebook Cell Number

--- a/README.md
+++ b/README.md
@@ -49,9 +49,17 @@ Use the following settings to update cell execution time for a notification and 
     // Settings for the Notifications extension
     // ****************************************
 
+    // Cell Number Type
+    // Type of cell number to display when the report_cell_number is true. Select from 'cell_index' or ‘cell_execution_count'.
+    "cell_number_type": "cell_index",
+
     // Enabled Status
     // Enable the extension or not.
     "enabled": true,
+
+    // Trigger only for the last notebook cell execution.
+    // Trigger a notification only for the last executed notebook cell
+    "last_cell_only": false,
 
     // Minimum Notebook Cell Execution Time
     // The minimum execution time to send out notification for a particular notebook cell (in seconds).
@@ -63,11 +71,7 @@ Use the following settings to update cell execution time for a notification and 
 
     // Report Notebook Cell Number
     // Display notebook cell number in the notification.
-    "report_cell_number": true,
-
-    // Cell Number Type
-    // Type of cell number to display when the report_cell_number is true. Select from 'cell_index' or ‘cell_execution_count'.
-    "cell_number_type": "cell_index"
+    "report_cell_number": true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Use the following settings to update cell execution time for a notification and 
     // Enable the extension or not.
     "enabled": true,
 
-    // Trigger only for the last notebook cell execution.
-    // Trigger a notification only for the last executed notebook cell
+    // Trigger only for the last selected notebook cell execution.
+    // Trigger a notification only for the last selected executed notebook cell.
     "last_cell_only": false,
 
     // Minimum Notebook Cell Execution Time

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,4 +4,4 @@ channels:
 dependencies:
 - jupyterlab=3
 - pip:
-  - jupyterlab-notifications==0.2.2
+  - jupyterlab-notifications==0.3.0

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -18,7 +18,7 @@
     "report_cell_execution_time": {
       "type": "boolean",
       "title": "Report Notebook Cell Execution Time",
-      "description": "Display notebook cell execution time in the notification.",
+      "description": "Display notebook cell execution time in the notification. If last_cell_only is set to true, the total duration of the selected cells will be displayed.",
       "default": true
     },
     "report_cell_number": {
@@ -37,7 +37,7 @@
     "last_cell_only": {
       "type": "boolean",
       "title": "Trigger only for the last selected notebook cell execution.",
-      "description": "Trigger a notification only for the last selected executed notebook cell",
+      "description": "Trigger a notification only for the last selected executed notebook cell.",
       "default": false
     }
   }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -28,11 +28,17 @@
       "default": true
     },
     "cell_number_type": {
-        "type": "string",
-        "title": "Cell Number Type",
-        "description": "Type of cell number to display when the report_cell_number is true. Select from 'cell_index' or ‘cell_execution_count'.",
-        "enum": ["cell_index", "cell_execution_count"],
-        "default": "cell_index"
-      }
+      "type": "string",
+      "title": "Cell Number Type",
+      "description": "Type of cell number to display when the report_cell_number is true. Select from 'cell_index' or ‘cell_execution_count'.",
+      "enum": ["cell_index", "cell_execution_count"],
+      "default": "cell_index"
+    },
+    "last_cell_only": {
+      "type": "boolean",
+      "title": "Trigger only for the last selected notebook cell execution.",
+      "description": "Trigger a notification only for the last selected executed notebook cell",
+      "default": false
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,18 +166,19 @@ const extension: JupyterFrontEndPlugin<void> = {
     NotebookActions.executed.connect((_, args) => {
       if (enabled && !lastCellOnly) {
         const { cell, notebook, success, error } = args;
-        triggerNotification(cell,
-                            notebook, 
-                            cellExecutionMetadataTable, 
-                            recentNotebookExecutionTimes,
-                            minimumCellExecutionTime,
-                            reportCellNumber,
-                            reportCellExecutionTime,
-                            cellNumberType,
-                            !success, 
-                            error,
-                            lastCellOnly);
-
+        triggerNotification(
+          cell,
+          notebook,
+          cellExecutionMetadataTable,
+          recentNotebookExecutionTimes,
+          minimumCellExecutionTime,
+          reportCellNumber,
+          reportCellExecutionTime,
+          cellNumberType,
+          !success,
+          error,
+          lastCellOnly
+        );
       }
     });
 
@@ -187,16 +188,17 @@ const extension: JupyterFrontEndPlugin<void> = {
         const failedExecution = false;
         triggerNotification(
           lastCell,
-          notebook, 
-          cellExecutionMetadataTable, 
+          notebook,
+          cellExecutionMetadataTable,
           recentNotebookExecutionTimes,
           minimumCellExecutionTime,
           reportCellNumber,
           reportCellExecutionTime,
           cellNumberType,
-          failedExecution, 
+          failedExecution,
           null,
-          lastCellOnly);
+          lastCellOnly
+        );
       }
     });
   }

--- a/tutorial/py3_demo.ipynb
+++ b/tutorial/py3_demo.ipynb
@@ -52,20 +52,74 @@
     }
    ],
    "source": [
-    "!sleep 66\n",
+    "!sleep 1\n",
     "print(\"hello world!\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 62,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2021-07-25T19:55:35.654800Z",
-     "iopub.status.busy": "2021-07-25T19:55:35.654567Z",
-     "iopub.status.idle": "2021-07-25T19:55:38.881008Z",
-     "shell.execute_reply": "2021-07-25T19:55:38.879628Z",
-     "shell.execute_reply.started": "2021-07-25T19:55:35.654769Z"
+     "iopub.execute_input": "2021-07-18T19:49:34.088207Z",
+     "iopub.status.busy": "2021-07-18T19:49:34.087802Z",
+     "iopub.status.idle": "2021-07-18T19:49:36.219369Z",
+     "shell.execute_reply": "2021-07-18T19:49:36.218766Z",
+     "shell.execute_reply.started": "2021-07-18T19:49:34.088134Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello world again!\n"
+     ]
+    }
+   ],
+   "source": [
+    "!sleep 2\n",
+    "print(\"hello world again!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-07-18T19:49:36.221581Z",
+     "iopub.status.busy": "2021-07-18T19:49:36.221322Z",
+     "iopub.status.idle": "2021-07-18T19:49:41.353081Z",
+     "shell.execute_reply": "2021-07-18T19:49:41.352358Z",
+     "shell.execute_reply.started": "2021-07-18T19:49:36.221557Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bye world!\n"
+     ]
+    }
+   ],
+   "source": [
+    "!sleep 5\n",
+    "print(\"bye world!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-07-18T19:41:58.007998Z",
+     "iopub.status.busy": "2021-07-18T19:41:58.007728Z",
+     "iopub.status.idle": "2021-07-18T19:42:01.145486Z",
+     "shell.execute_reply": "2021-07-18T19:42:01.144436Z",
+     "shell.execute_reply.started": "2021-07-18T19:41:58.007971Z"
     },
     "tags": []
    },
@@ -77,7 +131,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-99-d820d165a50b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mget_ipython\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msystem\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'sleep 3'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'hello world!'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m<ipython-input-40-d820d165a50b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mget_ipython\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msystem\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'sleep 3'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'hello world!'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[0;31mException\u001b[0m: hello world!"
      ]
     }


### PR DESCRIPTION
<img width="374" alt="Screen Shot 2021-07-18 at 3 49 44 PM" src="https://user-images.githubusercontent.com/3497137/126080566-c57a5bad-6712-4a0d-88aa-9cad7b3be123.png">
This adds an option to only get notified for the last selected cell. The last cell notification will show total duration instead of cell duration.

Select Multiple Cells: Shift + J or Shift + Down selects the next sell in a downwards direction. 

Closes #18 

@i-aki-y I'd appreciate your review!